### PR TITLE
Call previously-registered signal handlers during teardown

### DIFF
--- a/aws_logging_handlers/Kinesis/__init__.py
+++ b/aws_logging_handlers/Kinesis/__init__.py
@@ -218,15 +218,21 @@ class KinesisHandler(StreamHandler):
                                     **boto_session_kwargs)
 
         # Make sure we gracefully clear the buffers and upload the missing parts before exiting
-        signal.signal(signal.SIGTERM, self._teardown)
-        signal.signal(signal.SIGINT, self._teardown)
-        signal.signal(signal.SIGQUIT, self._teardown)
+        self._sigterm_handler = signal.signal(signal.SIGTERM, self._teardown)
+        self._sigint_handler = signal.signal(signal.SIGINT, self._teardown)
+        self._sigquit_handler = signal.signal(signal.SIGQUIT, self._teardown)
         atexit.register(self.close)
 
         StreamHandler.__init__(self, self.stream)
 
-    def _teardown(self, _: int, __):
+    def _teardown(self, signum: int, frame):
         self.close()
+        if signum == signal.SIGTERM:
+            self._sigterm_handler(signum, frame)
+        elif signum == signal.SIGINT:
+            self._sigint_handler(signum, frame)
+        elif signum == signal.SIGQUIT:
+            self._sigquit_handler(signum, frame)
 
     def close(self, *args, **kwargs):
         """


### PR DESCRIPTION
Thanks for the great library!

Currently, the handlers' constructors register new signal handlers to flush and close threads, but they do not call the previously registered handlers. This PR simply passes on signal handling.