### PR TITLE
Add support to SSE encryption

### DIFF
--- a/aws_logging_handlers/__init__.py
+++ b/aws_logging_handlers/__init__.py
@@ -7,4 +7,4 @@ evaluated upon community demand.
 """
 
 __author__ = 'Omri Eival'
-__version__ = '2.0.3'
+__version__ = '2.0.4'

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,13 @@ def read(fname):
 setup(
     name='aws-logging-handlers',
     packages=find_packages(),
-    version='2.0.3',
+    version='2.0.4',
     description='Logging aws_logging_handlers to AWS services that support S3 and Kinesis stream logging with multiple threads',
     long_description=read('README.rst'),
     author='Omri Eival',
     author_email='omrieival@gmail.com',
     url='https://github.com/omrikiei/aws_logging_handlers/',
-    download_url='https://github.com/omrikiei/aws_logging_handlers/archive/2.0.3.tar.gz',
+    download_url='https://github.com/omrikiei/aws_logging_handlers/archive/2.0.4.tar.gz',
     keywords=['logging', 's3', 'aws', 'handler', 'amazon', 'stream', 'kinesis', 'firehose'],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
I have modified the S3 handler to support SSE encryption. The argument that I have added can contain any of the officially supported parameters described [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Object.initiate_multipart_upload) 

I tested the implementation with the code here below on a bucket with SSE (default AWS S3 managed keys - AES256). 

```
import logging
from aws_logging_handlers.S3 import S3Handler

bucket = "my-bucket"  # The bucket should already exist and it should have server-side encryption enabled

encryption = {'ServerSideEncryption': 'AES256'}  # using SSE with AWS managed keys
# The log will be rotated to a new object either when an object reaches 5 MB or when 120 seconds pass from the last rotation/initial logging
s3_handler = S3Handler("logs/test.log", bucket, max_threads=3, encryption_options=encryption)
formatter = logging.Formatter('[%(asctime)s] %(filename)s:%(lineno)d} %(levelname)s - %(message)s')
s3_handler.setFormatter(formatter)
logger = logging.getLogger('root')
logger.setLevel(logging.INFO)
logger.addHandler(s3_handler)

for i in range(0, 100000):
    logger.info("test info message")
    logger.warning("test warning message")
    logger.error("test error message")

logging.shutdown()
```