### PR TITLE
Fixing an issue with parts order 

### DIFF
--- a/aws_logging_handlers/S3/__init__.py
+++ b/aws_logging_handlers/S3/__init__.py
@@ -210,7 +210,7 @@ class S3Stream(BufferedIOBase):
     def _close_stream(stream_object, callback=None, *args, **kwargs):
         stream_object.join_tasks()
         if stream_object.chunk_count > 0:
-            stream_object.uploader.complete(MultipartUpload={'Parts': stream_object.parts})
+            stream_object.uploader.complete(MultipartUpload={'Parts': sorted(stream_object.parts, lambda p: p['PartNumber'])})
         else:
             stream_object.uploader.abort()
 

--- a/aws_logging_handlers/S3/__init__.py
+++ b/aws_logging_handlers/S3/__init__.py
@@ -210,7 +210,7 @@ class S3Stream(BufferedIOBase):
     def _close_stream(stream_object, callback=None, *args, **kwargs):
         stream_object.join_tasks()
         if stream_object.chunk_count > 0:
-            stream_object.uploader.complete(MultipartUpload={'Parts': sorted(stream_object.parts, lambda p: p['PartNumber'])})
+            stream_object.uploader.complete(MultipartUpload={'Parts': sorted(stream_object.parts, key=lambda p: p['PartNumber'])})
         else:
             stream_object.uploader.abort()
 


### PR DESCRIPTION
Addressing the error below:

`botocore.exceptions.ClientError: An error occurred (InvalidPartOrder) when calling the CompleteMultipartUpload operation: The list of parts was not in ascending order. Parts must be ordered by part number.`